### PR TITLE
71 Upgrade Django to 1.9.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ coverage==4.1
 coveralls==1.1
 decorator==4.0.10
 dj-database-url==0.4.1
-Django==1.9.7
+Django==1.9.8
 django-toolbelt==0.0.1
 docopt==0.6.2
 flake8==3.0.4


### PR DESCRIPTION
#71

Upgrade Django installation from 1.9.7 to 1.9.8 to fix security issue according to https://docs.djangoproject.com/en/1.10/releases/1.9.8/.
