### PR TITLE
Change django admin title

### DIFF
--- a/core/settings/base.py
+++ b/core/settings/base.py
@@ -12,6 +12,9 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 
 import os
 import dotenv
+
+from django.contrib.admin import AdminSite
+
 dotenv.load()
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -130,3 +133,7 @@ STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'static'),
 )
+
+# Admin site settings
+AdminSite.site_header = 'Taverna Admin'
+AdminSite.index_title = 'Platform administration'


### PR DESCRIPTION
#78

Change Django admin title to `Taverna Admin`
Change Index title from `Site administration` to `Platform administration`

<img width="551" alt="screen shot 2016-09-28 at 4 27 06 pm" src="https://cloud.githubusercontent.com/assets/10073270/18920192/8aed1cc4-8598-11e6-89ab-436f29bdbae7.png">
