### PR TITLE
84 Return user-friendly error message for SlugifyMixin class

### DIFF
--- a/common/mixins.py
+++ b/common/mixins.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.text import slugify
+from django.utils.translation import ugettext_lazy as _
 
 
 class TimestampMixin(models.Model):
@@ -28,10 +29,12 @@ class SlugifyMixin():
 
     def clean(self):
         if hasattr(self, 'slugify_field') and hasattr(self, 'slug'):
-            self.slug = slugify(getattr(self, self.slugify_field))
+            slugify_field_value = getattr(self, self.slugify_field)
+            self.slug = slugify(slugify_field_value)
 
             if self.__class__.objects.filter(slug=self.slug).exists():
-                raise ValidationError("This object already exists.")
+                raise ValidationError(_("Entry with {0} - {1} already exists.".format(
+                                        self.slugify_field, slugify_field_value)))
 
     def save(self, *args, **kwargs):
         self.clean()


### PR DESCRIPTION
#84

Return user-friendly error message for SlugifyMixin class

An example is in the screenshot below
<img width="671" alt="screen shot 2016-09-29 at 12 16 07 pm" src="https://cloud.githubusercontent.com/assets/10073270/18951720/8a75a0d0-863e-11e6-972b-b5446385fbf4.png">
