### PR TITLE
77 Make date created and date modified fields visible on admin (updated)

### DIFF
--- a/app/timetables/admin.py
+++ b/app/timetables/admin.py
@@ -8,31 +8,62 @@ from .models import (
 @admin.register(Weekday, MealOption, Course)
 class DefaultAdmin(admin.ModelAdmin):
     """Default admin for models with just name and slug fields."""
+
     readonly_fields = ('slug',)
+
+
+class TimeStampAdmin(admin.ModelAdmin):
+    """Default admin for models having only readonly fields from TimeStampMixin."""
+
+    readonly_fields = ('date_created', 'date_modified')
 
 
 @admin.register(Meal)
 class MealAdmin(DefaultAdmin):
+    """Admin customisation for Meal model."""
+
     fields = ('name', 'slug', 'start_time', 'end_time')
 
 
 class AdminsInline(admin.TabularInline):
+    """Tabular inline setting for Timetable admins."""
+
     model = Timetable.admins.through
 
 
 @admin.register(Timetable)
-class TimetableAdmin(DefaultAdmin):
+class TimetableAdmin(admin.ModelAdmin):
+    """Admin customisation for Timetable model."""
+
+    readonly_fields = ('slug', 'date_created', 'date_modified')
     fields = ('name', 'slug', 'code', 'api_key', 'cycle_length',
               'current_cycle_day', 'description')
     inlines = (AdminsInline,)
 
 
 @admin.register(Dish)
-class DishAdmin(DefaultAdmin):
-    fields = ('name', 'slug', 'description')
+class DishAdmin(admin.ModelAdmin):
+    """Admin customisation for Dish model."""
+
+    readonly_fields = ('slug', 'date_created', 'date_modified')
+    fields = ('name', 'slug', 'description', 'date_created', 'date_modified')
+
+
+@admin.register(MenuItem)
+class MenuItemAdmin(TimeStampAdmin):
+    """Admin customisation for MenuItem model."""
+
+    fields = ('timetable', 'cycle_day', 'meal', 'meal_option', 'date_created', 'date_modified')
+
+
+@admin.register(Event)
+class EventAdmin(TimeStampAdmin):
+    """Admin customisation for Event model."""
+
+    fields = ('name', 'timetable', 'start_date', 'end_date', 'date_created', 'date_modified')
 
 
 admin.site.empty_value_display = ''
 
-other_models = [Event, Admin, MenuItem]
+other_models = [Admin]
 admin.site.register(other_models)


### PR DESCRIPTION
#77

Add admin customisation on read-only fields for Event model and comments to other model admins.
