### PR TITLE
Refactor GraphqlResponseFlattenerMiddleware to support multiple GraphQL request in a round trip.

### DIFF
--- a/app/api/tests/test_dish_api.py
+++ b/app/api/tests/test_dish_api.py
@@ -59,67 +59,77 @@ class DishApiTest(TestCase):
     def ordering_test_helper(self, ordering_param, records):
         # For ascending ordering
         query = 'query{dishes(orderBy: "%s") {edges{node{name}}}}' % (ordering_param)
-        expected = [
-            {
-                'name': records[0]
-            },
-            {
-                'name': records[1]
-            },
-            {
-                'name': records[2]
-            }
-        ]
+        expected = {
+            'dishes': [
+                {
+                    'name': records[0]
+                },
+                {
+                    'name': records[1]
+                },
+                {
+                    'name': records[2]
+                }
+            ]
+        }
         response = self.make_request(query)
         self.assertEqual(expected, response)
 
         # For descending ordering
         query = 'query {dishes(orderBy: "-%s") {edges{node{name}}}}' % (ordering_param)
-        expected.reverse()
+        expected['dishes'].reverse()
         response = self.make_request(query)
         self.assertEqual(expected, response)
 
     def test_creation_of_dish_object(self):
         # For new dish record
         response = self.create_dish(self.data['name'], self.data['description'])
+        created_dish = response['dish']
         expected = {
-            'id': response['id'],
-            'originalId': response['originalId'],
-            'name': self.data['name']
+            'dish': {
+                'id': created_dish['id'],
+                'originalId': created_dish['originalId'],
+                'name': self.data['name']
+            }
         }
         self.assertEqual(expected, response)
 
         # For existing weekday record
-        self.assertEqual(None, self.create_dish(self.data['name'], self.data['description']))
+        response = self.create_dish(self.data['name'], self.data['description'])
+        self.assertEqual({'dish': None}, response)
 
     def test_retrieval_of_one_dish_object(self):
         # Retrieve with valid id
         expected = {
-            'name': self.data['name']
+            'dish': {
+                'name': self.data['name']
+            }
         }
         create_response = self.create_dish(self.data['name'], self.data['description'])
-        response = self.retrieve_dish(create_response['id'])
+        response = self.retrieve_dish(create_response['dish']['id'])
         self.assertEqual(expected, response)
 
         # Retrieve with invalid id
-        self.assertEqual(None, self.retrieve_dish(2))
+        self.assertEqual({'dish': None}, self.retrieve_dish(2))
 
     def test_retrieval_of_multiple_dish_objects_without_filtering(self):
         self.create_multiple_dishes()
 
         query = 'query {dishes{edges{node{name}}}}'
 
-        expected = [
-            {
-                'name': self.dishes[0][0]
-            },
-            {
-                'name': self.dishes[1][0]
-            },
-            {
-                'name': self.dishes[2][0]
-            }
-        ]
+        expected = {
+            'dishes': [
+                {
+                    'name': self.dishes[0][0]
+                },
+                {
+                    'name': self.dishes[1][0]
+                },
+                {
+                    'name': self.dishes[2][0]
+                }
+            ]
+        }
 
         response = self.make_request(query)
 
@@ -129,14 +139,16 @@ class DishApiTest(TestCase):
         self.create_multiple_dishes()
         query = 'query {dishes(name_Icontains: "Rice") {edges{node{name}}}}'
 
-        expected = [
-            {
-                'name': self.dishes[0][0]
-            },
-            {
-                'name': self.dishes[1][0]
-            }
-        ]
+        expected = {
+            'dishes': [
+                {
+                    'name': self.dishes[0][0]
+                },
+                {
+                    'name': self.dishes[1][0]
+                }
+            ]
+        }
 
         response = self.make_request(query)
 
@@ -180,10 +192,12 @@ class DishApiTest(TestCase):
                     }
                 }
             }
-        ''' % (create_response['id'])
+        ''' % (create_response['dish']['id'])
         expected = {
-            'id': create_response['id'],
-            'name': 'rice edited'
+            'dish': {
+                'id': create_response['dish']['id'],
+                'name': 'rice edited'
+            }
         }
         response = self.make_request(query, 'POST')
         self.assertEqual(expected, response)
@@ -204,8 +218,8 @@ class DishApiTest(TestCase):
                     }
                 }
             }
-        ''' % ("wrong-id")
-        self.assertEqual(None, self.make_request(query, 'POST'))
+        ''' % ('wrong-id')
+        self.assertEqual({'dish': None}, self.make_request(query, 'POST'))
 
     def test_deletion_of_dish_object(self):
         # Delete with valid id
@@ -218,13 +232,15 @@ class DishApiTest(TestCase):
                     }
                 }
             }
-        ''' % (create_response['id'])
+        ''' % (create_response['dish']['id'])
         expected = {
-            "name": self.data['name']
+            'dish': {
+                'name': self.data['name']
+            }
         }
         response = self.make_request(query, 'POST')
         self.assertEqual(expected, response)
-        self.assertEqual(None, self.retrieve_dish(create_response['id']))
+        self.assertEqual({'dish': None}, self.retrieve_dish(create_response['dish']['id']))
 
         # Delete with invalid id
         query = '''
@@ -235,5 +251,5 @@ class DishApiTest(TestCase):
                     }
                 }
             }
-        ''' % ("wrong-id")
-        self.assertEqual(None, self.make_request(query, 'POST'))
+        ''' % ('wrong-id')
+        self.assertEqual({'dish': None}, self.make_request(query, 'POST'))

--- a/app/api/tests/test_user_api.py
+++ b/app/api/tests/test_user_api.py
@@ -16,7 +16,7 @@ class UserApiTest(TestCase):
                 self.client, *self.admin_test_credentials
             )
         }
-        self.first_user = self.create_user('oakeem', 'oatman')
+        self.first_user = self.create_user('oakeem', 'oatman')['user']
 
     def make_request(self, query, method='GET'):
         if method == 'GET':
@@ -59,28 +59,30 @@ class UserApiTest(TestCase):
     def ordering_test_helper(self, ordering_param, users):
         # For ascending ordering
         query = 'query{users(orderBy: "%s") {edges{node{username}}}}' % (ordering_param)
-        expected = [
-            {
-                'username': users[0]
-            },
-            {
-                'username': users[1]
-            },
-            {
-                'username': users[2]
-            },
-            {
-                'username': users[3]
-            },
-            {
-                'username': users[4]
-            }
-        ]
+        expected = {
+            'users': [
+                {
+                    'username': users[0]
+                },
+                {
+                    'username': users[1]
+                },
+                {
+                    'username': users[2]
+                },
+                {
+                    'username': users[3]
+                },
+                {
+                    'username': users[4]
+                }
+            ]
+        }
         self.assertEqual(expected, self.make_request(query))
 
         # For descending ordering
         query = 'query {users(orderBy: "-%s") {edges{node{username}}}}' % (ordering_param)
-        expected.reverse()
+        expected['users'].reverse()
         self.assertEqual(expected, self.make_request(query))
 
     def test_creation_of_user_object(self):
@@ -94,10 +96,13 @@ class UserApiTest(TestCase):
             credentials['username'],
             credentials['password']
         )
+        created_user = response['user']
         expected = {
-            'id': response['id'],
-            'originalId': response['originalId'],
-            'username': credentials['username']
+            'user': {
+                'id': created_user['id'],
+                'originalId': created_user['originalId'],
+                'username': created_user['username']
+            }
         }
         self.assertEqual(expected, response)
 
@@ -106,40 +111,44 @@ class UserApiTest(TestCase):
             credentials['username'],
             credentials['password']
         )
-        self.assertEqual(None, response)
+        self.assertEqual({'user': None}, response)
 
     def test_retrieval_of_one_user_object(self):
         # Retrieve with valid id
         expected = {
-            'username': self.first_user['username']
+            'user': {
+                'username': self.first_user['username']
+            }
         }
         self.assertEqual(expected, self.retrieve_user(self.first_user['id']))
 
         # Retrieve with invalid id
-        self.assertEqual(None, self.retrieve_user(100))
+        self.assertEqual({'user': None}, self.retrieve_user(100))
 
     def test_retrieval_of_multiple_user_objects_without_filtering(self):
         new_users = self.create_multiple_users()
 
         query = 'query {users{edges{node{username}}}}'
 
-        expected = [
-            {
-                'username': self.admin_test_credentials[0]
-            },
-            {
-                'username': self.first_user['username']
-            },
-            {
-                'username': new_users[0][0]
-            },
-            {
-                'username': new_users[1][0]
-            },
-            {
-                'username': new_users[2][0]
-            }
-        ]
+        expected = {
+           'users': [
+                {
+                    'username': self.admin_test_credentials[0]
+                },
+                {
+                    'username': self.first_user['username']
+                },
+                {
+                    'username': new_users[0][0]
+                },
+                {
+                    'username': new_users[1][0]
+                },
+                {
+                    'username': new_users[2][0]
+                }
+            ]
+        }
 
         self.assertEqual(expected, self.make_request(query))
 
@@ -148,14 +157,16 @@ class UserApiTest(TestCase):
 
         query = 'query {users(username_Icontains: "H") {edges{node{username}}}}'
 
-        expected = [
-            {
-                'username': new_users[0][0]
-            },
-            {
-                'username': new_users[1][0]
-            }
-        ]
+        expected = {
+            'users': [
+                {
+                    'username': new_users[0][0]
+                },
+                {
+                    'username': new_users[1][0]
+                }
+            ]
+        }
 
         self.assertEqual(expected, self.make_request(query))
 
@@ -164,11 +175,13 @@ class UserApiTest(TestCase):
 
         query = 'query {users(isStaff: true) {edges{node{username}}}}'
 
-        expected = [
-            {
-                'username': self.admin_test_credentials[0]
-            }
-        ]
+        expected = {
+            'users': [
+                {
+                    'username': self.admin_test_credentials[0]
+                }
+            ]
+        }
 
         self.assertEqual(expected, self.make_request(query))
 
@@ -177,11 +190,13 @@ class UserApiTest(TestCase):
 
         query = 'query {users(isActive: true) {edges{node{username}}}}'
 
-        expected = [
-            {
-                'username': self.admin_test_credentials[0]
-            }
-        ]
+        expected = {
+            'users': [
+                {
+                    'username': self.admin_test_credentials[0]
+                }
+            ]
+        }
 
         self.assertEqual(expected, self.make_request(query))
 
@@ -248,12 +263,14 @@ class UserApiTest(TestCase):
         ''' % (self.first_user['id'])
 
         expected = {
-            'id': self.first_user['id'],
-            'originalId': self.first_user['originalId'],
-            'username': 'oakeem',
-            'firstName': 'Akeem',
-            'lastName': 'Oduola',
-            'email': 'akeem.oduola@andela.com',
+            'user': {
+                'id': self.first_user['id'],
+                'originalId': self.first_user['originalId'],
+                'username': 'oakeem',
+                'firstName': 'Akeem',
+                'lastName': 'Oduola',
+                'email': 'akeem.oduola@andela.com',
+            }
         }
 
         self.assertEqual(expected, self.make_request(query, 'POST'))
@@ -282,7 +299,7 @@ class UserApiTest(TestCase):
                 }
             }
         ''' % ('wrong-id')
-        self.assertEqual(None, self.make_request(query, 'POST'))
+        self.assertEqual({'user': None}, self.make_request(query, 'POST'))
 
     def test_deletion_of_user_object(self):
         # Delete with valid id
@@ -297,11 +314,13 @@ class UserApiTest(TestCase):
         ''' % (self.first_user['id'])
 
         expected = {
-            'username': self.first_user['username']
+            'user': {
+                'username': self.first_user['username']
+            }
         }
 
         self.assertEqual(expected, self.make_request(query, 'POST'))
-        self.assertEqual(None, self.retrieve_user(self.first_user['id']))
+        self.assertEqual({'user': None}, self.retrieve_user(self.first_user['id']))
 
         # Delete with invalid id
         query = '''
@@ -313,4 +332,4 @@ class UserApiTest(TestCase):
                 }
             }
         ''' % ('wrong-id')
-        self.assertEqual(None, self.make_request(query, 'POST'))
+        self.assertEqual({'user': None}, self.make_request(query, 'POST'))

--- a/app/api/tests/test_weekday_api.py
+++ b/app/api/tests/test_weekday_api.py
@@ -17,7 +17,7 @@ class WeekdayApiTest(TestCase):
             )
         }
         self.weekdays = ('weekday1', 'weekday2',)
-        self.first_weekday = self.create_weekday('day1')
+        self.first_weekday = self.create_weekday('day1')['weekday']
 
     def make_request(self, query, method='GET'):
         if method == 'GET':
@@ -52,43 +52,50 @@ class WeekdayApiTest(TestCase):
     def test_creation_of_weekday_object(self):
         # For new weekday record
         response = self.create_weekday('day2')
+        created_weekday = response['weekday']
         expected = {
-            'id': response['id'],
-            'originalId': response['originalId'],
-            'name': 'day2'
+            'weekday': {
+                'id': created_weekday['id'],
+                'originalId': created_weekday['originalId'],
+                'name': 'day2'
+            }
         }
         self.assertEqual(expected, response)
 
         # For existing weekday record
-        self.assertEqual(None, self.create_weekday('day1'))
+        self.assertEqual({'weekday': None}, self.create_weekday('day1'))
 
     def test_retrieve_weekday_object(self):
         # Retrieve with valid id
         response = self.retrieve_weekday(self.first_weekday['id'])
         expected = {
-            'name': self.first_weekday['name']
+            'weekday': {
+                'name': self.first_weekday['name']
+            }
         }
         self.assertEqual(expected, response)
 
         # Retrieve with invalid id
-        self.assertEqual(None, self.retrieve_weekday(100))
+        self.assertEqual({'weekday': None}, self.retrieve_weekday(100))
 
     def test_retrieve_multiple_weekdays_without_filtering(self):
         self.create_multiple_weekdays()
 
         query = 'query {weekdays{edges{node{name}}}}'
 
-        expected = [
-            {
-                'name': self.first_weekday['name']
-            },
-            {
-                'name': self.weekdays[0]
-            },
-            {
-                'name': self.weekdays[1]
-            }
-        ]
+        expected = {
+            'weekdays': [
+                {
+                    'name': self.first_weekday['name']
+                },
+                {
+                    'name': self.weekdays[0]
+                },
+                {
+                    'name': self.weekdays[1]
+                }
+            ]
+        }
 
         response = self.make_request(query)
 
@@ -98,14 +105,16 @@ class WeekdayApiTest(TestCase):
         self.create_multiple_weekdays()
         query = 'query {weekdays(name_Icontains: "day1") {edges{node{name}}}}'
 
-        expected = [
-            {
-                'name': self.first_weekday['name']
-            },
-            {
-                'name': self.weekdays[0]
-            }
-        ]
+        expected = {
+            'weekdays': [
+                {
+                    'name': self.first_weekday['name']
+                },
+                {
+                    'name': self.weekdays[0]
+                }
+            ]
+        }
 
         response = self.make_request(query)
 
@@ -132,9 +141,11 @@ class WeekdayApiTest(TestCase):
         ''' % (self.first_weekday['id'])
         response = self.make_request(query, 'POST')
         expected = {
-            'id': self.first_weekday['id'],
-            'originalId': self.first_weekday['originalId'],
-            'name': 'day3'
+            'weekday': {
+                'id': self.first_weekday['id'],
+                'originalId': self.first_weekday['originalId'],
+                'name': 'day3'
+            }
         }
         self.assertEqual(expected, response)
 
@@ -156,7 +167,7 @@ class WeekdayApiTest(TestCase):
                 }
             }
         ''' % (100)
-        self.assertEqual(None, self.make_request(query, 'POST'))
+        self.assertEqual({'weekday': None}, self.make_request(query, 'POST'))
 
     def test_deletion_weekday_object(self):
         # Delete with valid id
@@ -171,10 +182,12 @@ class WeekdayApiTest(TestCase):
         ''' % (self.first_weekday['id'])
         response = self.make_request(query, 'POST')
         expected = {
-            'name': self.first_weekday['name']
+            'weekday': {
+                'name': self.first_weekday['name']
+            }
         }
         self.assertEqual(expected, response)
-        self.assertEqual(None, self.retrieve_weekday(self.first_weekday['id']))
+        self.assertEqual({'weekday': None}, self.retrieve_weekday(self.first_weekday['id']))
 
         # Delete with invalid id
         query = '''
@@ -186,4 +199,4 @@ class WeekdayApiTest(TestCase):
                 }
             }
         ''' % (100)
-        self.assertEqual(None, self.make_request(query, 'POST'))
+        self.assertEqual({'weekday': None}, self.make_request(query, 'POST'))

--- a/common/middleware.py
+++ b/common/middleware.py
@@ -10,29 +10,39 @@ class GraphqlResponseFlattenerMiddleware(object):
     def __call__(self, request):
         response = self.get_response(request)
         try:
-            res = json.loads(response.content.decode())
+            content = json.loads(response.content.decode())
         except json.JSONDecodeError:
             return response
 
-        if request.method == 'GET':
-            # Use case for retrieval of non-exitent record
-            if 'data' in res and list(res['data'].values())[0] is None:
-                res = None
-            # Use case for retrieval of all records
-            elif 'data' in res and 'edges' in list(res['data'].values())[0]:
-                res = list(list(res['data'].values())[0].values())[0]
-                res = [list(item.values())[0] for item in res]
-            # Use case for retrieval of a single existing record
-            elif 'data' in res and isinstance(list(res['data'].values())[0], dict):
-                res = list(res['data'].values())[0]
-        elif request.method == 'POST':
-            # Use case for creating, deleting and updating a record
-            if 'data' in res and isinstance(list(list(res['data'].values())[0].values())[0], dict):
-                res = list(list(res['data'].values())[0].values())[0]
-            # Use case for deleting and updating a record
-            elif 'data' in res and list(list(res['data'].values())[0].values())[0] is None:
-                res = None
+        if 'data' in content and request.method == 'GET':
+            flattened_content = {}
+            index = 0
+            for resource in list(content['data'].values()):
+                # Use case for retrieval of all records
+                if (resource and 'edges' in resource
+                        and isinstance(resource['edges'], list)
+                        and 'node' in resource['edges'][0]):
 
-        response.content = json.dumps(res)
+                    flattened_content[list(content['data'].keys())[index]] = []
+                    for item in list(resource.values())[0]:
+                        flattened_content[
+                            list(content['data'].keys())[index]
+                        ].append(list(item.values())[0])
 
+                # Use case for retrieval a record
+                elif resource is None or isinstance(resource, dict):
+                    flattened_content[list(content['data'].keys())[index]] = resource
+
+                index += 1
+            content = flattened_content
+        elif 'data' in content and request.method == 'POST':
+            flattened_content = {}
+            for resource in list(content['data'].values()):
+                if resource:
+                    item = list(resource.values())[0]
+                    if item is None or isinstance(item, dict):
+                        flattened_content[list(resource.keys())[0]] = item
+            content = flattened_content
+
+        response.content = json.dumps(content)
         return response


### PR DESCRIPTION
#195 