### PR TITLE
Refactor servings removing the restriction of supplying vendor for retrieval

### DIFF
--- a/app/api/schema.py
+++ b/app/api/schema.py
@@ -50,10 +50,12 @@ class Query(graphene.AbstractType):
 
     def resolve_servings(self, args, context, info):
         timetable = Timetable.objects.get(slug=args['timetable'])
-        vendor = Vendor.objects.get(slug=args['vendor'])
         date = datetime.strptime(args['date'], '%Y-%m-%d').date()
+        if 'vendor' in args:
+            vendor = Vendor.objects.get(slug=args['vendor'])
+            return ServingAutoUpdate.get_servings(timetable, date, vendor=vendor)
 
-        return ServingAutoUpdate.get_servings(timetable, vendor, date)
+        return ServingAutoUpdate.get_servings(timetable, date)
 
 
 class Mutation(graphene.ObjectType):

--- a/app/timetables/models.py
+++ b/app/timetables/models.py
@@ -336,21 +336,27 @@ class ServingAutoUpdate(models.Model):
             )
 
     @classmethod
-    def get_servings(cls, timetable, vendor, date):
-        cls.verify_vendor_is_serving(timetable, vendor, date)
+    def get_servings(cls, timetable, date, vendor=None):
+        if vendor:
+            cls.verify_vendor_is_serving(timetable, vendor, date)
+            vendors = [vendor]
+        else:
+            vendors = Vendor.objects.all()
+
         menu_items = cls.get_menu_items(timetable, date)
 
-        kwargs = {
-            'timetable': timetable,
-            'vendor': vendor,
-            'date': date
-        }
-        if not cls.objects.filter(**kwargs).exists():
-            cls.objects.create(**kwargs)
+        for vendor in vendors:
+            kwargs = {
+                'timetable': timetable,
+                'vendor': vendor,
+                'date': date
+            }
+            if not cls.objects.filter(**kwargs).exists():
+                cls.objects.create(**kwargs)
 
         return Serving.objects.filter(
             menu_item__in=menu_items,
-            vendor=vendor,
+            vendor__in=vendors,
             date_served=date
         )
 

--- a/app/timetables/tests/test_models.py
+++ b/app/timetables/tests/test_models.py
@@ -396,13 +396,17 @@ class ServingAutoUpdateTest(TestCase):
         self.assertRaises(
             ValidationError,
             ServingAutoUpdate.get_servings,
-            self.timetable, self.vendor, self.later_date
+            self.timetable, self.later_date, vendor=self.vendor
         )
 
     def test_get_servings_for_a_date_earlier_than_ref_cycle_date(self):
         try:
             with transaction.atomic():
-                ServingAutoUpdate.get_servings(self.timetable, self.vendor, self.earlier_date)
+                ServingAutoUpdate.get_servings(
+                    self.timetable,
+                    self.earlier_date,
+                    vendor=self.vendor
+                )
         except ValidationError as e:
             self.assertEqual(
                 ['Supply a date later than or equal to {}'.format(self.date)],
@@ -416,7 +420,7 @@ class ServingAutoUpdateTest(TestCase):
         self.assertRaises(
             ValidationError,
             ServingAutoUpdate.get_servings,
-            self.timetable, self.vendor, self.date
+            self.timetable, self.date, vendor=self.vendor
         )
 
     def test_get_servings_for_right_combination_of_timetable_and_vendor_and_date(self):
@@ -433,7 +437,25 @@ class ServingAutoUpdateTest(TestCase):
         )
 
         # After get_servings is called
-        servings = ServingAutoUpdate.get_servings(self.timetable, self.vendor, self.date)
+        servings = ServingAutoUpdate.get_servings(self.timetable, self.date, vendor=self.vendor)
+        self.assertIsInstance(ServingAutoUpdate.objects.get(**kwargs), ServingAutoUpdate)
+        self.assertEqual(3, len(servings))
+        self.assertIsInstance(servings[0], Serving)
+
+    def test_get_servings_for_right_combination_of_timetable_and_date_without_vendor(self):
+        # Before get_servings is called
+        kwargs = {
+            'timetable': self.timetable,
+            'date': self.date
+        }
+        self.assertRaises(
+            ServingAutoUpdate.DoesNotExist,
+            ServingAutoUpdate.objects.get,
+            **kwargs
+        )
+
+        # After get_servings is called
+        servings = ServingAutoUpdate.get_servings(self.timetable, self.date)
         self.assertIsInstance(ServingAutoUpdate.objects.get(**kwargs), ServingAutoUpdate)
         self.assertEqual(3, len(servings))
         self.assertIsInstance(servings[0], Serving)


### PR DESCRIPTION
Graphql clients can now make GET request without supplying a value for the vendor param.